### PR TITLE
fix: evenout verticalspacing at promo in home page

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -1306,7 +1306,7 @@ blockquote {
   .xs-service-promo span {
     color: #012C6D;
     display: inline-block;
-    margin-bottom: 30px;
+    /* margin-bottom: 30px; */
     font-size: 4.28571em; }
   .xs-service-promo .color-orange {
     color: #f7a900; }

--- a/src/components/Promo.svelte
+++ b/src/components/Promo.svelte
@@ -29,7 +29,7 @@
             <div class="col-md-6 col-lg-3 text-center">
                 <div class="xs-service-promo">
                     <span><i class="fas fa-book-open"></i></span>
-                    <h5>Bantuan Buku <br>Untuk Siswa Yang Membutuhkan</h5>
+                    <h5>Bantuan Buku Untuk Siswa Yang Membutuhkan</h5>
                     <p>Buku adalah salah satu sumber belajar bagi banyak siswa-siswi di Indonesia, namun masih ada yang terkendala untuk membelinya. Freeducation ada untuk mengatasi masalah tersebut.</p>
                 </div><!-- .xs-service-promo END -->
             </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/57476855/146027847-bcad454f-5666-4308-a6fe-e4c69e896135.png)

to

![image](https://user-images.githubusercontent.com/57476855/146027970-0bb35efb-9873-45d6-af3f-e65e4f790f61.png)
